### PR TITLE
modify latch API to match std::experimental

### DIFF
--- a/include/ecst/utils/cv_operations/cv_operations.hpp
+++ b/include/ecst/utils/cv_operations/cv_operations.hpp
@@ -96,6 +96,13 @@ ECST_NAMESPACE
                 },
                 FWD(f));
         }
+
+        void wait_counter(
+            mutex_type& mutex, cv_type& cv, counter_type& c) noexcept
+        {
+            unique_lock_type l(mutex);
+            cv.wait(l, [&c]{ return c == 0; });
+        }
     }
 }
 ECST_NAMESPACE_END

--- a/include/ecst/utils/cv_operations/latch.hpp
+++ b/include/ecst/utils/cv_operations/latch.hpp
@@ -23,6 +23,8 @@ ECST_NAMESPACE
         /// @brief Constructs a latch with `initial_count` counter value.
         latch(impl::counter_inner_type initial_count) noexcept;
 
+        void count_down() noexcept;
+
         /// @brief Decrements the counter and notifies one thread waiting on the
         /// `condition_variable`.
         /// @details Asserts `_counter` to be greater than zero.
@@ -39,6 +41,8 @@ ECST_NAMESPACE
         /// will decrement the counter to zero.
         template <typename TF>
         void execute_and_wait_until_zero(TF&& f) noexcept(noexcept(f()));
+
+        void wait() noexcept;
     };
 }
 ECST_NAMESPACE_END

--- a/include/ecst/utils/cv_operations/latch.inl
+++ b/include/ecst/utils/cv_operations/latch.inl
@@ -16,6 +16,11 @@ ECST_NAMESPACE
     {
     }
 
+    void latch::count_down() noexcept
+    {
+        --_counter;
+    }
+
     void latch::decrement_and_notify_one() noexcept
     {
         impl::decrement_cv_counter_and_notify_one(_mutex, _cv, _counter);
@@ -32,6 +37,10 @@ ECST_NAMESPACE
     {
         impl::execute_and_wait_until_counter_zero(
             _mutex, _cv, _counter, FWD(f));
+    }
+
+    void latch::wait() noexcept {
+        impl::wait_counter(_mutex, _cv, _counter);
     }
 }
 ECST_NAMESPACE_END


### PR DESCRIPTION
I want to be able to decrement the latch without notifying any waiting threads. The std::experimental/boost interface has the ability to only notify waiting threads when the counter decrements to zero and to decrement and notify from different contexts.